### PR TITLE
Add boto dep for S3 storage backend

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,9 @@ scrapy-splash
 scrapy-crawlera
 scrapy-dotpersistence
 scrapy-pagestorage
+
+# Scrapy S3 storage backend requires boto
+boto
 # Images addon needs Pillow
 Pillow
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@
 -e git+https://github.com/scrapy/scrapely@39e7d2c7#egg=scrapely
 -e git+https://github.com/scrapinghub/portia@401cba9#egg=slybot==dev&subdirectory=slybot
 attrs==15.2.0             # via service-identity
+boto==2.39.0
 cffi==1.6.0               # via cryptography
 cryptography==1.3.2       # via pyopenssl
 cssselect==0.9.1          # via parsel, scrapy


### PR DESCRIPTION
S3 storage backend requires boto (http://doc.scrapy.org/en/latest/topics/feed-exports.html#s3).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrapinghub/scrapinghub-stack-portia/5)

<!-- Reviewable:end -->
