### PR TITLE
Adding bsddb3 for DeltaFetch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -qq && \
     apt-get install -qy \
         netbase ca-certificates apt-transport-https \
         build-essential locales \
+        libdb5.3-dev \
         libxml2-dev \
         libssl-dev \
         libxslt1-dev \
@@ -26,6 +27,9 @@ RUN apt-get update -qq && \
         ghostscript
 # http://unix.stackexchange.com/questions/195975/cannot-force-remove-directory-in-docker-build
 #        && rm -rf /var/lib/apt/lists
+
+# Setting environment for bsddb3 install (deltafetch addon)
+ENV BERKELEYDB_DIR=/usr
 
 # Custom entrypoint in json format passed via environment
 ENV ENTRYPOINT='["/usr/local/sbin/portia-entrypoint"]'

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,8 @@ scrapy-pagestorage
 
 # Scrapy S3 storage backend requires boto
 boto
+# Adding bsddb package for DeltaFetch addon
+bsddb3
 # Images addon needs Pillow
 Pillow
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@
 -e git+https://github.com/scrapinghub/portia@401cba9#egg=slybot==dev&subdirectory=slybot
 attrs==15.2.0             # via service-identity
 boto==2.39.0
+bsddb3==6.1.1
 cffi==1.6.0               # via cryptography
 cryptography==1.3.2       # via pyopenssl
 cssselect==0.9.1          # via parsel, scrapy


### PR DESCRIPTION
The patch adds DeltaFetch support for Portia crawlers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrapinghub/scrapinghub-stack-portia/6)

<!-- Reviewable:end -->
