### PR TITLE
Pass portia-entrypoint to SHUB namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,11 @@ ENV SHUB_ENTRYPOINT='["/usr/local/sbin/portia-entrypoint"]'
 # Backward compatibility while migration to SHUB namespace
 ENV ENTRYPOINT='["/usr/local/sbin/portia-entrypoint"]'
 
+COPY requirements.txt /requirements-portia.txt
+RUN pip install --no-cache-dir -r requirements-portia.txt
+
 COPY portia-entrypoint /usr/local/sbin/
 
 COPY eggbased-entrypoint /usr/local/sbin/
 RUN chmod +x /usr/local/sbin/eggbased-entrypoint && \
     ln -s /usr/local/sbin/eggbased-entrypoint /usr/local/sbin/start-crawl
-
-COPY requirements.txt /requirements-portia.txt
-RUN pip install --no-cache-dir -r requirements-portia.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ RUN locale-gen
 ENV BERKELEYDB_DIR=/usr
 
 # Custom entrypoint in json format passed via environment
+ENV SHUB_ENTRYPOINT='["/usr/local/sbin/portia-entrypoint"]'
+# Backward compatibility while migration to SHUB namespace
 ENV ENTRYPOINT='["/usr/local/sbin/portia-entrypoint"]'
+
 COPY portia-entrypoint /usr/local/sbin/
 
 COPY eggbased-entrypoint /usr/local/sbin/

--- a/eggbased-entrypoint
+++ b/eggbased-entrypoint
@@ -61,12 +61,20 @@ def unpack_egg(eggpath):
     return newpath
 
 
+def _print_flush(s):
+    """Debug helper to track entrypoints execution"""
+    print('eggbased-entrypoint: ' + s)
+    sys.stdout.flush()
+
+
 def main():
+    _print_flush("entered")
     os.environ.update(DEFAULT_ENV)
     eggs_env = load_eggs(DEFAULT_EGGS_PATH, DEFAULT_MAIN_EGG_NAME)
     os.environ.update(eggs_env)
 
     cmd = os.path.basename(sys.argv[0])
+    _print_flush("exec env: %s" % os.environ)
     if cmd == 'scrapy-list':
         os.execvp('scrapy', ['scrapy', 'list'])
     elif cmd == 'start-crawl':

--- a/portia-entrypoint
+++ b/portia-entrypoint
@@ -83,9 +83,17 @@ def update_environment_for_portia():
     return env
 
 
+def _print_flush(s):
+    """Debug helper to track entrypoints execution"""
+    print("portia-entrypoint: " + s)
+    sys.stdout.flush()
+
+
 def main():
+    _print_flush("entered")
     prepare_portia_bundle()
     env = update_environment_for_portia()
+    _print_flush("exec env: %s" % env)
     if len(sys.argv) > 1:
         os.execvpe(sys.argv[1], sys.argv[1:], env)
     else:


### PR DESCRIPTION
We have to pass portia-entrypoint via env variable in both ways while migration process.

Review, please.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrapinghub/scrapinghub-stack-portia/14)

<!-- Reviewable:end -->
