### PR TITLE
Update scrapinghub-entrypoint-scrapy for custom UA

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ python-slugify
 Pillow
 
 # pinned for custom UA for hubstorage client
-scrapinghub-entrypoint-scrapy>=0.8.8
+scrapinghub-entrypoint-scrapy>=0.8.9
 
 # Portia deps
 -e git+https://github.com/scrapy/scrapely@b88b49c#egg=scrapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+
 -e git+https://github.com/scrapinghub/dateparser@9b6597d#egg=dateparser
 -e git+https://github.com/scrapy/scrapely@b88b49c#egg=scrapely
 -e git+https://github.com/scrapinghub/portia@0526b93#egg=slybot==dev&subdirectory=slybot
 attrs==15.2.0             # via service-identity
-backports.ssl-match-hostname==3.5.0.1  # via websocket-client
 boto==2.39.0
 bsddb3==6.1.1
 cffi==1.6.0               # via cryptography
@@ -49,7 +49,7 @@ requests==2.10.0          # via hubstorage, monkeylearn, slackclient
 retrying==1.3.3           # via hubstorage
 s3cmd==1.6.1              # via scrapy-dotpersistence
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.8.8
+scrapinghub-entrypoint-scrapy==0.8.9
 scrapy-crawlera==1.1.0
 scrapy-dotpersistence==0.2.2
 scrapy-pagestorage==0.1.0


### PR DESCRIPTION
Updating `scrapinghub-entrypoint-scrapy` as an ability to set custom UA goes with `0.8.9` [version](https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/commit/538e9f25516370788fd81c69ddd375ba99424dc4).