### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,65 +8,65 @@
 -e git+https://github.com/scrapy/scrapely@b88b49c#egg=scrapely
 -e git+https://github.com/scrapinghub/portia@1b920f1#egg=slybot==dev&subdirectory=slybot
 attrs==15.2.0             # via service-identity
-backports.ssl-match-hostname==3.5.0.1  # via websocket-client
+awscli==1.11.23           # via scrapy-dotpersistence
 boto==2.39.0
+botocore==1.4.80          # via awscli, s3transfer
 bsddb3==6.1.1
 cffi==1.6.0               # via cryptography
+colorama==0.3.7           # via awscli
 cryptography==1.3.2       # via pyopenssl
 cssselect==0.9.1          # via parsel, premailer, scrapy
 cssutils==1.0.1           # via premailer
-enum34==1.1.4             # via cryptography
-functools32==3.2.3.post2  # via jsonschema
-hubstorage==0.23.2        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
+docutils==0.12            # via awscli, botocore
+hubstorage==0.23.5        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
 idna==2.1                 # via cryptography
-ipaddress==1.0.16         # via cryptography
 jdatetime==1.8.1
-Jinja2==2.8
+jinja2==2.8
+jmespath==0.9.0           # via botocore
 jsonschema==2.5.1
 loginform==1.2.0
 lxml==3.6.0               # via loginform, parsel, premailer, scrapy
-MarkupSafe==0.23          # via jinja2
+markupsafe==0.23          # via jinja2
 mock==1.0.1               # via schematics
 monkeylearn==0.3.5
 numpy==1.11.0             # via page-finder
 page-finder==0.1.7
 parsel==1.0.2             # via scrapy
-Pillow==3.2.0
+pillow==3.2.0
 premailer==2.9.2
 pyasn1-modules==0.0.8     # via service-identity
-pyasn1==0.1.9             # via cryptography, pyasn1-modules, service-identity
+pyasn1==0.1.9             # via cryptography, pyasn1-modules, rsa, service-identity
 pycparser==2.14           # via cffi
-PyDispatcher==2.0.5       # via scrapy
-pyOpenSSL==16.0.0         # via scrapy, service-identity
-python-dateutil==2.5.3    # via s3cmd
-python-magic==0.4.11      # via s3cmd
+pydispatcher==2.0.5       # via scrapy
+pyopenssl==16.0.0         # via scrapy, service-identity
+python-dateutil==2.5.3    # via botocore
 python-slugify==1.2.1
 pytz==2016.4
-PyYAML==3.11
+pyyaml==3.11              # via awscli
 queuelib==1.4.2           # via scrapy
 regex==2016.4.25
 requests==2.10.0          # via hubstorage, monkeylearn, slackclient
 retrying==1.3.3           # via hubstorage
-s3cmd==1.6.1              # via scrapy-dotpersistence
+rsa==3.4.2                # via awscli
+s3transfer==0.1.9         # via awscli
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.8.9
+scrapinghub-entrypoint-scrapy==0.8.10
 scrapy-crawlera==1.1.0
-scrapy-dotpersistence==0.2.2
+scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.1.0
 scrapy-splash==0.6.1
-Scrapy==1.1.0rc4          # via scrapinghub-entrypoint-scrapy, scrapy-dotpersistence, scrapy-pagestorage, scrapylib
+scrapy==1.1.0rc4
 scrapyjs==0.2
 scrapylib==1.7.0
 service-identity==16.0.0  # via scrapy
 six==1.10.0
 slackclient==1.0.1
-Twisted==16.1.1           # via scrapy
+twisted==16.1.1           # via scrapy
 umalqurra==0.2
-Unidecode==0.4.19         # via python-slugify
+unidecode==0.4.19         # via python-slugify
 w3lib==1.14.2             # via parsel, scrapy
 websocket-client==0.37.0  # via slackclient
 zope.interface==4.1.3     # via twisted
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via cryptography, zope.interface


### PR DESCRIPTION
Main changes are:
- updating sh-entrypoint-scrapy up to 0.8.10
- updating scrapy-dotpersistence up to 0.3.0
- updating hubstorage from 0.23.2 to 0.23.5

All other changes were triggered by `pip-compile`, it enforces lower-case mode now (I guess because of https://github.com/nvie/pip-tools/issues/311).  