### PR TITLE
Update SH bindings

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,6 +19,7 @@ Jinja2
 jsonschema
 premailer==2.9.2
 schematics==1.0.4
+scrapinghub==1.9.0
 slackclient
 python-slugify
 # Images addon needs Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.12            # via awscli, botocore
 enum34==1.1.6             # via cryptography
 functools32==3.2.3.post2  # via jsonschema
 futures==3.0.5            # via s3transfer
-hubstorage==0.23.6        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
+hubstorage==0.23.6        # via scrapy-pagestorage
 idna==2.1                 # via cryptography
 ipaddress==1.0.17         # via cryptography
 jdatetime==1.8.1
@@ -54,7 +54,7 @@ retrying==1.3.3           # via hubstorage, scrapinghub
 rsa==3.4.2                # via awscli
 s3transfer==0.1.9         # via awscli
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.8.10
+scrapinghub-entrypoint-scrapy==0.8.11
 scrapinghub==1.9.0
 scrapy-crawlera==1.1.0
 scrapy-dotpersistence==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,12 @@ cryptography==1.3.2       # via pyopenssl
 cssselect==0.9.1          # via parsel, premailer, scrapy
 cssutils==1.0.1           # via premailer
 docutils==0.12            # via awscli, botocore
-hubstorage==0.23.5        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
+enum34==1.1.6             # via cryptography
+functools32==3.2.3.post2  # via jsonschema
+futures==3.0.5            # via s3transfer
+hubstorage==0.23.6        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
 idna==2.1                 # via cryptography
+ipaddress==1.0.17         # via cryptography
 jdatetime==1.8.1
 jinja2==2.8
 jmespath==0.9.0           # via botocore
@@ -45,12 +49,13 @@ pytz==2016.4
 pyyaml==3.11              # via awscli
 queuelib==1.4.2           # via scrapy
 regex==2016.4.25
-requests==2.10.0          # via hubstorage, monkeylearn, slackclient
-retrying==1.3.3           # via hubstorage
+requests==2.10.0          # via hubstorage, monkeylearn, scrapinghub, slackclient
+retrying==1.3.3           # via hubstorage, scrapinghub
 rsa==3.4.2                # via awscli
 s3transfer==0.1.9         # via awscli
 schematics==1.0.4
 scrapinghub-entrypoint-scrapy==0.8.10
+scrapinghub==1.9.0
 scrapy-crawlera==1.1.0
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.1.0


### PR DESCRIPTION
- adding `python-scrapinghub==1.9.0`
- updating `python-hubstorage==0.23.6`

All other changes were triggered by pip-compile, it enforces lower-case mode now.

@ruairif Wonder if we should upgrade Scrapy version as a part of this PR.

Review, please.