### PR TITLE
No need to chown bundle eggs

### DIFF
--- a/portia-entrypoint
+++ b/portia-entrypoint
@@ -17,7 +17,6 @@ import requests
 from retrying import retry
 from sh_scrapy.env import decode_uri
 
-GID = 65534
 
 DEFAULT_DASH_URL = "https://app.scrapinghub.com/api/"
 DASH_BUNDLE_PATH = '/tmp/eggs-bundle.zip'
@@ -120,12 +119,6 @@ def unpack_eggs_bundle():
         zf.extractall(DASH_PACKED_EGGS_PATH)
     except BadZipfile as exc:
         _print_flush("Bad zipfile %s" % exc)
-    else:
-        uid = int(os.environ.get('SHUB_JOB_UID', 65534))
-        for eggname in os.listdir(DASH_PACKED_EGGS_PATH):
-            eggpath = os.path.join(DASH_PACKED_EGGS_PATH, eggname)
-            if os.path.isfile(eggpath) and eggname.endswith('.egg'):
-                os.chown(eggpath, uid, GID)
 
 
 def load_dash_eggs(eggs_paths):


### PR DESCRIPTION
We don't need to chown bundle eggs after unpacking as the entrypoint is already executed as nobody user, and except for the changes are redundant - it causes an exception because `SHUB_JOB_UID` is already cleaned at this step and default value is used instead of a proper one.