### PR TITLE
Add scrapy-deltafetch package

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ page_finder
 scrapylib
 scrapy-splash
 scrapy-crawlera
+scrapy-deltafetch
 scrapy-dotpersistence
 scrapy-pagestorage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@
 appdirs==1.4.0            # via setuptools
 attrs==15.2.0             # via service-identity
 awscli==1.11.23           # via scrapy-dotpersistence
-backports.ssl-match-hostname==3.5.0.1  # via websocket-client
 boto==2.39.0
 botocore==1.4.80          # via awscli, s3transfer
 bsddb3==6.1.1
@@ -62,6 +61,7 @@ schematics==1.0.4
 scrapinghub-entrypoint-scrapy==0.9.0
 scrapinghub==1.9.0
 scrapy-crawlera==1.1.0
+scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.1.0
 scrapy-splash==0.6.1
@@ -77,6 +77,5 @@ w3lib==1.16.0             # via parsel, scrapy
 websocket-client==0.37.0  # via slackclient
 zope.interface==4.1.3     # via twisted
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via cryptography, zope.interface


### PR DESCRIPTION
The new entrypoint (starting from `0.8.12` version) updates Deltafetch plugin location from `scrapylib` to `scrapy-deltafetch` package, which is absent in the stack, let's fix it.