### PR TITLE
portia-entrypoint retries: retrying library expects milliseconds

### DIFF
--- a/portia-entrypoint
+++ b/portia-entrypoint
@@ -84,7 +84,8 @@ def backoffretry_delays(maxwait=3600, maxdelay=600, mindelay=0):
         w += s
         if w > maxwait:
             break
-        delays.append(s)
+        # retrying.retry expects milliseconds from wait_func
+        delays.append(s * 1000)
     return delays
 
 


### PR DESCRIPTION
This logic returns proper delays in milliseconds: `[60000,  60000,  60000,  60000, 60000, 60000, 60000, 60000, 64000, 81000, 100000, 121000, 144000, 169000]`

Please, review.