### PR TITLE
Use latest Scrapy, update related deps

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-scrapy==1.5.0
+scrapy==1.6.0
 loginform>=1.2.0
 page_finder
 scrapylib

--- a/requirements.in
+++ b/requirements.in
@@ -33,3 +33,11 @@ scrapinghub-entrypoint-scrapy>=0.8.9
 -e git+https://github.com/scrapy/scrapely@ff8af77#egg=scrapely
 -e git+https://github.com/scrapinghub/dateparser@cb23f53#egg=dateparser
 -e git+https://github.com/scrapinghub/portia@09ad116#egg=slybot==dev&subdirectory=slybot
+
+# address known vulnerabilities
+awscli>=1.16.179    # fix pyaml dependency
+Twisted>=19.2.1     # CVE-2019-12387
+urllib3>=1.24.2     # CVE-2019-11324
+Jinja2>=2.10.1      # CVE-2019-10906
+requests>=2.20.0    # CVE-2018-18074
+pyyaml>=4.2b1       # CVE-2017-18342

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,70 +7,76 @@
 -e git+https://github.com/scrapinghub/dateparser@cb23f53#egg=dateparser
 -e git+https://github.com/scrapy/scrapely@ff8af77#egg=scrapely
 -e git+https://github.com/scrapinghub/portia@09ad116#egg=slybot==dev&subdirectory=slybot
-asn1crypto==0.22.0        # via cryptography
-attrs==17.1.0             # via automat, service-identity
-automat==0.6.0            # via twisted
-awscli==1.11.90           # via scrapy-dotpersistence
-boto==2.46.1
-botocore==1.5.53          # via awscli, s3transfer
-bsddb3==6.2.4
-cffi==1.10.0              # via cryptography
-chardet==3.0.3
-colorama==0.3.7           # via awscli
+asn1crypto==0.24.0        # via cryptography
+attrs==19.1.0             # via automat, jsonschema, service-identity, twisted
+automat==0.7.0            # via twisted
+awscli==1.16.164          # via scrapy-dotpersistence
+boto==2.49.0
+botocore==1.12.154        # via awscli, s3transfer
+bsddb3==6.2.6
+certifi==2019.3.9         # via requests
+cffi==1.12.3              # via cryptography
+chardet==3.0.4            # via requests
+colorama==0.3.9           # via awscli
 constantly==15.1.0        # via twisted
-cryptography==1.8.1       # via pyopenssl
-cssselect==1.0.1          # via parsel, premailer, scrapy
+cryptography==2.6.1       # via pyopenssl, service-identity
+cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
-docutils==0.13.1          # via awscli, botocore
-hyperlink==18.0.0         # via twisted
-idna==2.5                 # via cryptography, hyperlink
-incremental==16.10.1      # via twisted
-jinja2==2.9.6
-jmespath==0.9.2           # via botocore
-jsonschema==2.6.0
+docutils==0.14            # via awscli, botocore
+enum34==1.1.6             # via cryptography
+functools32==3.2.3.post2  # via jsonschema, parsel
+futures==3.2.0            # via s3transfer
+hyperlink==19.0.0         # via twisted
+idna==2.8                 # via hyperlink, requests
+incremental==17.5.0       # via twisted
+ipaddress==1.0.22         # via cryptography, service-identity
+jinja2==2.10.1
+jmespath==0.9.4           # via botocore
+jsonschema==3.0.1
 loginform==1.2.0
-lxml==3.7.3               # via loginform, parsel, premailer, scrapy
-markupsafe==1.0           # via jinja2
+lxml==4.3.3               # via loginform, parsel, premailer, scrapy
+markupsafe==1.1.1         # via jinja2
 mock==1.0.1               # via schematics
-monkeylearn==0.3.7
-numpy==1.12.1             # via page-finder
-packaging==16.8           # via cryptography
+monkeylearn==3.2.4
+numpy==1.16.3             # via page-finder
 page-finder==0.1.9
 parsel==1.5.1             # via scrapy
-pillow==5.2.0
+pillow==6.0.0
 premailer==2.9.2
-pyasn1-modules==0.0.8     # via service-identity
-pyasn1==0.2.3             # via pyasn1-modules, rsa, service-identity
-pycparser==2.17           # via cffi
+pyasn1-modules==0.2.5     # via service-identity
+pyasn1==0.4.5             # via pyasn1-modules, rsa, service-identity
+pycparser==2.19           # via cffi
 pydispatcher==2.0.5       # via scrapy
-pyopenssl==17.0.0         # via scrapy, service-identity
-pyparsing==2.2.0          # via packaging
-python-dateutil==2.6.0    # via botocore
-python-slugify==1.2.4
-pytz==2017.2              # via tzlocal
-pyyaml==3.12              # via awscli
-queuelib==1.4.2           # via scrapy
-regex==2017.4.29
-requests==2.14.2          # via monkeylearn, scrapinghub, slackclient
+pyhamcrest==1.9.0         # via twisted
+pyopenssl==19.0.0         # via scrapy
+pyrsistent==0.15.2        # via jsonschema
+python-dateutil==2.8.0    # via botocore
+python-slugify==3.0.2
+pytz==2019.1              # via tzlocal
+pyyaml==3.13              # via awscli
+queuelib==1.5.0           # via scrapy
+regex==2019.4.14
+requests==2.22.0          # via monkeylearn, scrapinghub, slackclient
 retrying==1.3.3           # via scrapinghub
 rsa==3.4.2                # via awscli
-s3transfer==0.1.10        # via awscli
+s3transfer==0.2.0         # via awscli
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.10.2
+scrapinghub-entrypoint-scrapy==0.11.2
 scrapinghub==2.0.3
-scrapy-crawlera==1.2.2
+scrapy-crawlera==1.5.1
 scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
-scrapy-pagestorage==0.2.0
+scrapy-pagestorage==0.2.2
 scrapy-splash==0.7.2
 scrapy==1.6.0
 scrapylib==1.7.1
-service-identity==16.0.0  # via scrapy
-six==1.10.0
-slackclient==1.0.5
-twisted==17.9.0           # via scrapy
-tzlocal==1.4
-unidecode==0.4.20         # via python-slugify
-w3lib==1.20.0             # via parsel, scrapy
-websocket-client==0.40.0  # via slackclient
-zope.interface==4.4.1     # via twisted
+service-identity==18.1.0  # via scrapy
+six==1.12.0
+slackclient==1.3.1
+text-unidecode==1.2       # via python-slugify
+twisted==19.2.0           # via scrapy
+tzlocal==1.5.1
+urllib3==1.24.3           # via botocore, requests
+w3lib==1.20.0             # via parsel, scrapy, scrapy-crawlera
+websocket-client==0.54.0  # via slackclient
+zope.interface==4.6.0     # via twisted

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ monkeylearn==0.3.7
 numpy==1.12.1             # via page-finder
 packaging==16.8           # via cryptography
 page-finder==0.1.9
-parsel==1.2.0             # via scrapy
+parsel==1.5.1             # via scrapy
 pillow==5.2.0
 premailer==2.9.2
 pyasn1-modules==0.0.8     # via service-identity
@@ -63,7 +63,7 @@ scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.2.0
 scrapy-splash==0.7.2
-scrapy==1.5.0
+scrapy==1.6.0
 scrapylib==1.7.1
 service-identity==16.0.0  # via scrapy
 six==1.10.0
@@ -71,6 +71,6 @@ slackclient==1.0.5
 twisted==17.9.0           # via scrapy
 tzlocal==1.4
 unidecode==0.4.20         # via python-slugify
-w3lib==1.17.0             # via parsel, scrapy
+w3lib==1.20.0             # via parsel, scrapy
 websocket-client==0.40.0  # via slackclient
 zope.interface==4.4.1     # via twisted

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 -e git+https://github.com/scrapy/scrapely@ff8af77#egg=scrapely
 -e git+https://github.com/scrapinghub/portia@09ad116#egg=slybot==dev&subdirectory=slybot
 asn1crypto==0.24.0        # via cryptography
-attrs==19.1.0             # via automat, jsonschema, service-identity, twisted
+attrs==19.1.0             # via automat, service-identity, twisted
 automat==0.7.0            # via twisted
 awscli==1.16.164          # via scrapy-dotpersistence
 boto==2.49.0
@@ -24,7 +24,7 @@ cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 docutils==0.14            # via awscli, botocore
 enum34==1.1.6             # via cryptography
-functools32==3.2.3.post2  # via jsonschema, parsel
+functools32==3.2.3.post2  # via parsel
 futures==3.2.0            # via s3transfer
 hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, requests
@@ -32,9 +32,9 @@ incremental==17.5.0       # via twisted
 ipaddress==1.0.22         # via cryptography, service-identity
 jinja2==2.10.1
 jmespath==0.9.4           # via botocore
-jsonschema==3.0.1
+jsonschema==2.6.0
 loginform==1.2.0
-lxml==4.3.3               # via loginform, parsel, premailer, scrapy
+lxml==3.7.3               # via loginform, parsel, premailer, scrapy
 markupsafe==1.1.1         # via jinja2
 mock==1.0.1               # via schematics
 monkeylearn==3.2.4
@@ -49,7 +49,6 @@ pycparser==2.19           # via cffi
 pydispatcher==2.0.5       # via scrapy
 pyhamcrest==1.9.0         # via twisted
 pyopenssl==19.0.0         # via scrapy
-pyrsistent==0.15.2        # via jsonschema
 python-dateutil==2.8.0    # via botocore
 python-slugify==3.0.2
 pytz==2019.1              # via tzlocal

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@
 asn1crypto==0.24.0        # via cryptography
 attrs==19.1.0             # via automat, service-identity, twisted
 automat==0.7.0            # via twisted
-awscli==1.16.164          # via scrapy-dotpersistence
+awscli==1.16.180
 boto==2.49.0
-botocore==1.12.154        # via awscli, s3transfer
+botocore==1.12.170        # via awscli, s3transfer
 bsddb3==6.2.6
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
@@ -24,7 +24,7 @@ cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 docutils==0.14            # via awscli, botocore
 enum34==1.1.6             # via cryptography
-functools32==3.2.3.post2  # via parsel
+functools32==3.2.3.post2  # via jsonschema, parsel
 futures==3.2.0            # via s3transfer
 hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, requests
@@ -52,10 +52,10 @@ pyopenssl==19.0.0         # via scrapy
 python-dateutil==2.8.0    # via botocore
 python-slugify==3.0.2
 pytz==2019.1              # via tzlocal
-pyyaml==3.13              # via awscli
+pyyaml==5.1
 queuelib==1.5.0           # via scrapy
 regex==2019.4.14
-requests==2.22.0          # via monkeylearn, scrapinghub, slackclient
+requests==2.22.0
 retrying==1.3.3           # via scrapinghub
 rsa==3.4.2                # via awscli
 s3transfer==0.2.0         # via awscli
@@ -73,9 +73,9 @@ service-identity==18.1.0  # via scrapy
 six==1.12.0
 slackclient==1.3.1
 text-unidecode==1.2       # via python-slugify
-twisted==19.2.0           # via scrapy
+twisted==19.2.1
 tzlocal==1.5.1
-urllib3==1.24.3           # via botocore, requests
+urllib3==1.24.3
 w3lib==1.20.0             # via parsel, scrapy, scrapy-crawlera
 websocket-client==0.54.0  # via slackclient
 zope.interface==4.6.0     # via twisted


### PR DESCRIPTION
While updating Scrapy in the stack, I realized that almost all dependencies should be updated. Most of them have minor updates only, but some of them changed major version (in alphabetical order):
- attrs 17.1.0 -> 19.1.0 
- cryptography 1.8.1 - >2.6.1 (which should be fine, we use 2.5 in scrapy:1.6 stack)
- hyperlink 18.0.0 -> 19.0.0
- incremental 16.10.1 -> 17.5.0
- jsonschema 2.6.0 -> 3.0.1
- lxml 3.7.3 - > 4.3.3
- monkeylearn 0.3.7 -> 3.2.4
- pillow 5.2.0 -> 6.0.0
- pyopenssl 17.0.0 -> 19.0.0
- python-slugify 1.2.4->3.0.2
- pytz 2017.2 -> 2019.1
- regex 2017.4.29->2019.4.14
- service-identity 16.0.0 -> 18.1.0
- twisted 17.9.0 -> 19.2.0 

Most significant ones are cryptography, lxml, pillow, pyopenssl and twisted, but we already use the new major versions of the libs in scrapy:1.6 stack (except for twisted, it's 18.9 in 1.6 stack). 

@ruairif I'm not that familiar with Portia stack, requesting for your help on the PR. We could also split it: make 1st release with changes from [the commit](https://github.com/scrapinghub/scrapinghub-stack-portia/pull/37/commits/01530b2cca4d83cb4d4968d02db39878eadf2ee3) plus cryptography update, and 2nd release with all other dependencies updated. Wdyt?