### PR TITLE
Add missing addons packages

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,10 @@ scrapy-splash
 scrapy-crawlera
 scrapy-deltafetch
 scrapy-dotpersistence
+scrapy-magicfields
 scrapy-pagestorage
+scrapy-querycleaner
+scrapy-splitvariants
 
 # Scrapy S3 storage backend requires boto
 boto

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,8 +65,11 @@ scrapinghub==2.0.3
 scrapy-crawlera==1.5.1
 scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
+scrapy-magicfields==1.1.0
 scrapy-pagestorage==0.2.2
+scrapy-querycleaner==1.0.0
 scrapy-splash==0.7.2
+scrapy-splitvariants==1.1.0
 scrapy==1.6.0
 scrapylib==1.7.1
 service-identity==18.1.0  # via scrapy


### PR DESCRIPTION
After recent sh-entrypoint-scrapy [update](https://github.com/scrapinghub/scrapinghub-stack-portia/commit/257d49ce40ef1e77256684ee512ba4f73d82cb79#diff-b4ef698db8ca845e5845c4618278f29aR64), the addons rely on [the new paths](https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/blob/687a7edcfc3b1d12cba766ff8705e6e3618f1efe/sh_scrapy/settings.py#L12-L27) and related separate packages instead of using deprecated [scrapylib](https://github.com/scrapinghub/scrapylib).